### PR TITLE
accept FIPS endpoints

### DIFF
--- a/builder/builder_runner.go
+++ b/builder/builder_runner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
-const ECR_REPO_REGEX = `[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*`
+const ECR_REPO_REGEX = `[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr(-fips)?\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*`
 
 type Builder struct {
 	RegistryURL                string


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

AWS makes available FIPS-140 compliant endpoints for services including ECR (https://aws.amazon.com/compliance/fips/). Currently, the ecrhelper fails when attempting to use these endpoints.

This change can be tested with the existing builder_test.go and setting `ECR_TEST_REPO_URI` to a FIPS endpoint: https://github.com/cloudfoundry/dockerapplifecycle/blob/80b4aa4715a00f7c48d714ff48a3b35310b93172/builder/builder_test.go#L372.

A similar change has been integrated in the ecrhelper: https://github.com/cloudfoundry/ecrhelper/pull/5.

Backward Compatibility
---------------
Breaking Change? **No**

The change is additive. Existing non-fips endpoints are valid.
